### PR TITLE
Added NewImmediateLooper(); updated README + godoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,15 @@ iteration per 5 seconds, we can just substitute a `TimedLooper`:
 looper := NewTimedLooper(1, 5 * time.Second, make(chan error))
 go RunForever(looper)
 ```
+
+Lastly, a timed looper will only execute once the tick interval has been met. To immediately execute the first iteration of the loop, you can instantiate an immediate timed looper via the `NewImmediateTimedLooper` function.
+
+Or in other words:
+
+```go
+looper := NewImmediateTimedLooper(10, 5 * time.Second, make(chan error))
+go looper.Loop(func() error { fmt.Println("Immediate execution"); return nil })
+time.Sleep(10 * time.Second)
+
+// STDOUT: "Immediate execution" output as soon as looper.Loop() is ran.
+```

--- a/director_test.go
+++ b/director_test.go
@@ -60,6 +60,16 @@ func Test_TimedLooper(t * testing.T) {
 	})
 }
 
+func Test_NewImmediateTimedLooper(t *testing.T) {
+	Convey("ImmediateTimedLooper", t, func() {
+		looper := NewImmediateTimedLooper(10, 1 * time.Nanosecond, make(chan error))
+
+		Convey("Immediate looper must have immediate set to true", func() {
+			So(looper.Immediate, ShouldBeTrue)
+		})
+	})
+}
+
 func Test_FreeLooper(t * testing.T) {
 	Convey("FreeLooper", t, func() {
 		looper := NewFreeLooper(1, make(chan error))


### PR DESCRIPTION
NewImmediateLooper() is exactly the same as a NewTimedLooper() except it will
immediately run the first iteration of the loop instead of waiting for the tick
to complete.

Tests pass - all looks good.
