### PR TITLE
Immediate quit and fix bugs

### DIFF
--- a/.travis
+++ b/.travis
@@ -1,0 +1,13 @@
+language: go
+
+go:
+  - 1.11.x
+
+sudo: required
+
+install:
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.10.2
+
+script:
+  - golangci-lint run
+  - go test -v -race --timeout 1m

--- a/director.go
+++ b/director.go
@@ -116,13 +116,14 @@ func (l *TimedLooper) Loop(fn func() error) {
 
 	ticker := time.NewTicker(l.Interval)
 	defer ticker.Stop()
-
-	for range ticker.C {
-		if stop {
-			break
+	for {
+		select {
+		case <-ticker.C:
+			runIteration()
+		case <-l.quitChan:
+			stopFunc(nil)
+			return
 		}
-
-		runIteration()
 	}
 }
 

--- a/director.go
+++ b/director.go
@@ -77,7 +77,6 @@ func (l *TimedLooper) Loop(fn func() error) {
 	i := 0
 
 	var stop bool
-
 	stopFunc := func(err error) {
 		l.Done(err)
 		stop = true
@@ -99,13 +98,6 @@ func (l *TimedLooper) Loop(fn func() error) {
 				return
 			}
 		}
-
-		select {
-		case <-l.quitChan:
-			stopFunc(nil)
-			return
-		default:
-		}
 	}
 
 	// Immediatelly run our function if we've been instantiated via
@@ -117,12 +109,19 @@ func (l *TimedLooper) Loop(fn func() error) {
 	ticker := time.NewTicker(l.Interval)
 	defer ticker.Stop()
 	for {
+		// The execution loop needs to be able to stop automatically
+		// after l.Count iterations. It does so when runIteration
+		// invokes stopFunc, which sets `stop` to false.
+		if stop {
+			break
+		}
+
 		select {
 		case <-ticker.C:
 			runIteration()
 		case <-l.quitChan:
 			stopFunc(nil)
-			return
+			break
 		}
 	}
 }

--- a/director_test.go
+++ b/director_test.go
@@ -40,7 +40,7 @@ func Test_TimedLooper(t *testing.T) {
 			count := 0
 			looper.Count = 5
 			go looper.Loop(func() error { count++; return nil })
-			looper.Wait()
+			So(looper.Wait(), ShouldBeNil)
 
 			So(count, ShouldEqual, 5)
 		})
@@ -59,7 +59,10 @@ func Test_TimedLooper(t *testing.T) {
 			looper.Quit()
 
 			So(looper.Wait(), ShouldBeNil)
-			So(count, ShouldBeLessThan, 2)
+
+			previousCount := count
+			time.Sleep(1 * time.Millisecond)
+			So(count, ShouldEqual, previousCount)
 		})
 	})
 }
@@ -96,7 +99,7 @@ func Test_FreeLooper(t *testing.T) {
 		Convey("The loop executes the function", func() {
 			run := false
 			go looper.Loop(func() error { run = true; return nil })
-			looper.Wait()
+			So(looper.Wait(), ShouldBeNil)
 
 			So(run, ShouldBeTrue)
 		})
@@ -105,7 +108,7 @@ func Test_FreeLooper(t *testing.T) {
 			count := 0
 			looper.Count = 5
 			go looper.Loop(func() error { count++; return nil })
-			looper.Wait()
+			So(looper.Wait(), ShouldBeNil)
 
 			So(count, ShouldEqual, 5)
 		})
@@ -124,7 +127,10 @@ func Test_FreeLooper(t *testing.T) {
 			looper.Quit()
 
 			So(looper.Wait(), ShouldBeNil)
-			So(count, ShouldBeLessThan, 2)
+
+			previousCount := count
+			time.Sleep(1 * time.Millisecond)
+			So(count, ShouldEqual, previousCount)
 		})
 	})
 }
@@ -144,7 +150,10 @@ func ExampleTimedLooper() {
 	}
 
 	go runner(looper)
-	looper.Wait()
+	err := looper.Wait()
+	if err != nil {
+		fmt.Printf("I got an error: %s\n", err.Error())
+	}
 
 	// Output:
 	// 0
@@ -173,7 +182,10 @@ func ExampleTimedLooper_Quit() {
 	// Wait for one run to complete
 	time.Sleep(90 * time.Millisecond)
 	looper.Quit()
-	looper.Wait()
+	err := looper.Wait()
+	if err != nil {
+		fmt.Printf("I got an error: %s\n", err.Error())
+	}
 
 	// Output:
 	// 0

--- a/director_test.go
+++ b/director_test.go
@@ -170,6 +170,8 @@ func ExampleTimedLooper_Quit() {
 	}
 
 	go runner(looper)
+	// Wait for one run to complete
+	time.Sleep(90 * time.Millisecond)
 	looper.Quit()
 	looper.Wait()
 


### PR DESCRIPTION
This pulls in @actaeon's enhancement from https://github.com/newrelic-forks/go-director/pull/2 as 6fb99ea.

I noticed that the change made some tests fail, so I started digging into the logic and it looks like the `stop` boolean cannot be removed as I explained in 6a003cd. Otherwise, the `stopFunc` becomes ineffective, unless users call `looper.Quit()` after `looper.Wait()`, but calling `looper.Wait()` alone should be sufficient to stop looping after `l.Count` iterations.

Also, I it looks like the `select` block from `runIteration` became redundant after the logic was duplicated in the event loop of `TimedLooper.Loop()` in 6fb99ea. I removed it.

I also found some tests which were sometimes flaky and triggered assertions when running them with `go test -race`, so I changed them slightly to be more robust.

Lastly, I created a `.travis` file, which should work for this project if you don't mind enabling it.